### PR TITLE
글 리스트에서도 ‘나도’ 누르기

### DIFF
--- a/app/(tabs)/posts/page.tsx
+++ b/app/(tabs)/posts/page.tsx
@@ -37,9 +37,18 @@ async function getFeeds(userId: number) {
     include: {
       user: {
         select: {
+          id: true,
           username: true,
           login_id: true,
           avatar: true,
+        },
+      },
+      reposts: {
+        where: {
+          userId,
+        },
+        select: {
+          id: true,
         },
       },
       _count: {
@@ -59,6 +68,7 @@ async function getFeeds(userId: number) {
     include: {
       user: {
         select: {
+          id: true,
           username: true,
           login_id: true,
           avatar: true,
@@ -68,9 +78,18 @@ async function getFeeds(userId: number) {
         include: {
           user: {
             select: {
+              id: true,
               username: true,
               login_id: true,
               avatar: true,
+            },
+          },
+          reposts: {
+            where: {
+              userId,
+            },
+            select: {
+              id: true,
             },
           },
           _count: {
@@ -102,7 +121,7 @@ export default async function Posts() {
 
   return (
     <Layout title="모아보는" showNewPostBtn>
-      <Timeline posts={posts} reposts={reposts} />
+      <Timeline posts={posts} reposts={reposts} userId={userId} />
     </Layout>
   );
 }

--- a/components/buttons/post-preview-buttons.tsx
+++ b/components/buttons/post-preview-buttons.tsx
@@ -52,7 +52,7 @@ export default function PostPreviewButtons({
           onClick={onRepostClick}
           className={`flex items-center gap-1 border py-1 px-2 rounded-md ${
             state.isUserReposted
-              ? "text-white bg-violet-400 hover:bg-violet-300 dark:bg-violet-500 dark:hover:bg-violet-400 border-violet-600 dark:border-violet-800"
+              ? "text-white bg-violet-400 hover:bg-violet-300 border-violet-600 dark:border-violet-800"
               : "bg-white hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-700"
           }`}
         >

--- a/components/buttons/post-preview-buttons.tsx
+++ b/components/buttons/post-preview-buttons.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { repost, unrepost } from "@/app/(tabs)/posts/[id]/action";
+import {
+  ArrowPathRoundedSquareIcon,
+  ChatBubbleOvalLeftEllipsisIcon,
+} from "@heroicons/react/24/outline";
+import { startTransition, useOptimistic } from "react";
+
+interface PostPreviewButtonsProps {
+  postId: number;
+  isUserReposted: boolean;
+  isUserPost: boolean;
+  repostCount: number;
+  commentCount: number;
+}
+
+export default function PostPreviewButtons({
+  postId,
+  isUserReposted,
+  isUserPost,
+  repostCount,
+  commentCount,
+}: PostPreviewButtonsProps) {
+  const [state, reducerFn] = useOptimistic(
+    { isUserReposted, repostCount },
+    (prevState) => ({
+      isUserReposted: !prevState.isUserReposted,
+      repostCount: prevState.isUserReposted
+        ? prevState.repostCount - 1
+        : prevState.repostCount + 1,
+    })
+  );
+
+  const onRepostClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    startTransition(() => reducerFn(undefined));
+    if (isUserReposted) {
+      await unrepost(postId);
+    } else {
+      await repost(postId);
+    }
+  };
+
+  return (
+    <div className="flex gap-2 self-end mt-4 text-neutral-600 dark:text-neutral-100">
+      {!isUserPost ? (
+        <button
+          type="button"
+          onClick={onRepostClick}
+          className={`flex items-center gap-1 border py-1 px-2 rounded-md bg-white hover:bg-neutral-100 ${
+            state.isUserReposted
+              ? "dark:bg-violet-500 dark:hover:bg-violet-400 border-violet-800"
+              : "dark:bg-neutral-900 dark:hover:bg-neutral-700"
+          }`}
+        >
+          <ArrowPathRoundedSquareIcon className="size-4" />
+          <p className="text-sm">{state.repostCount}</p>
+        </button>
+      ) : (
+        <div className="flex items-center gap-1 border dark:border-neutral-400 py-1 px-2 rounded-md bg-white hover:bg-neutral-100 dark:bg-neutral-600 dark:hover:bg-neutral-600 dark:text-neutral-400 cursor-not-allowed">
+          <ArrowPathRoundedSquareIcon className="size-4" />
+          <p className="text-sm">{state.repostCount}</p>
+        </div>
+      )}
+      <div className="flex items-center gap-1 border py-1 px-2 rounded-md bg-white hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-700">
+        <ChatBubbleOvalLeftEllipsisIcon className="size-4" />
+        <p className="text-sm">{commentCount}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/buttons/post-preview-buttons.tsx
+++ b/components/buttons/post-preview-buttons.tsx
@@ -50,17 +50,17 @@ export default function PostPreviewButtons({
         <button
           type="button"
           onClick={onRepostClick}
-          className={`flex items-center gap-1 border py-1 px-2 rounded-md bg-white hover:bg-neutral-100 ${
+          className={`flex items-center gap-1 border py-1 px-2 rounded-md ${
             state.isUserReposted
-              ? "dark:bg-violet-500 dark:hover:bg-violet-400 border-violet-800"
-              : "dark:bg-neutral-900 dark:hover:bg-neutral-700"
+              ? "text-white bg-violet-400 hover:bg-violet-300 dark:bg-violet-500 dark:hover:bg-violet-400 border-violet-600 dark:border-violet-800"
+              : "bg-white hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-700"
           }`}
         >
           <ArrowPathRoundedSquareIcon className="size-4" />
           <p className="text-sm">{state.repostCount}</p>
         </button>
       ) : (
-        <div className="flex items-center gap-1 border dark:border-neutral-400 py-1 px-2 rounded-md bg-white hover:bg-neutral-100 dark:bg-neutral-600 dark:hover:bg-neutral-600 dark:text-neutral-400 cursor-not-allowed">
+        <div className="flex items-center gap-1 border py-1 px-2 rounded-md bg-white dark:bg-neutral-900 text-neutral-400 dark:border-neutral-400 cursor-not-allowed">
           <ArrowPathRoundedSquareIcon className="size-4" />
           <p className="text-sm">{state.repostCount}</p>
         </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -3,19 +3,21 @@
 import Link from "next/link";
 import { PostWithUser } from "./timeline";
 import { formatRelativeTime } from "@/libs/utils";
-import {
-  ArrowPathRoundedSquareIcon,
-  ChatBubbleOvalLeftEllipsisIcon,
-} from "@heroicons/react/24/outline";
 import Image from "next/image";
+import PostPreviewButtons from "./buttons/post-preview-buttons";
 
 interface PostPreviewProps {
   post: PostWithUser;
+  userId: number;
 }
 
 export default function PostPreview({
-  post: { id, user, content, tags, created_at, _count },
+  post: { id, user, content, tags, created_at, _count, reposts },
+  userId,
 }: PostPreviewProps) {
+  const isUserPost = Number(user.id) === userId;
+  const isUserReposted = reposts.some((repost) => repost?.id);
+
   return (
     <Link href={`/posts/${id}`}>
       <div className="w-full p-4 text-left flex flex-col gap-3">
@@ -43,16 +45,13 @@ export default function PostPreview({
         <p className="text-sm text-neutral-400">{tags}</p>
 
         {/* 버튼부 */}
-        <div className="flex gap-2 self-end mt-4 text-neutral-600 dark:text-neutral-100">
-          <button className="flex items-center gap-1 border py-1 px-2 rounded-md bg-white hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-700">
-            <ArrowPathRoundedSquareIcon className="size-4" />
-            <p className="text-sm">{_count.reposts}</p>
-          </button>
-          <button className="flex items-center gap-1 border py-1 px-2 rounded-md bg-white hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-700">
-            <ChatBubbleOvalLeftEllipsisIcon className="size-4" />
-            <p className="text-sm">{_count.comments}</p>
-          </button>
-        </div>
+        <PostPreviewButtons
+          postId={id}
+          isUserReposted={isUserReposted}
+          isUserPost={isUserPost}
+          repostCount={_count.reposts}
+          commentCount={_count.comments}
+        />
       </div>
     </Link>
   );

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -4,10 +4,12 @@ import EmptyStateFooter from "@/components/layouts/empty-state-has-footer";
 
 export interface PostWithUser extends Post {
   user: {
+    id: number;
     username: string;
     login_id: string;
     avatar: string | null;
   };
+  reposts: { id?: number }[];
   _count: {
     comments: number;
     reposts: number;
@@ -16,6 +18,7 @@ export interface PostWithUser extends Post {
 
 export interface RepostWithUser extends Repost {
   user: {
+    id: number;
     username: string;
     login_id: string;
     avatar: string | null;
@@ -26,9 +29,10 @@ export interface RepostWithUser extends Repost {
 interface TimelineProps {
   posts: PostWithUser[];
   reposts: RepostWithUser[];
+  userId: number;
 }
 
-export default function Timeline({ posts, reposts }: TimelineProps) {
+export default function Timeline({ posts, reposts, userId }: TimelineProps) {
   const allPosts = [...posts, ...reposts];
   allPosts.sort(
     (prev, curr) =>
@@ -39,7 +43,9 @@ export default function Timeline({ posts, reposts }: TimelineProps) {
     <section className="flex flex-col divide-y divide-neutral-200 dark:divide-neutral-600">
       {allPosts.length ? (
         allPosts.map((post) =>
-          "content" in post ? <PostPreview post={post} key={post.id} /> : null
+          "content" in post ? (
+            <PostPreview key={post.id} post={post} userId={userId} />
+          ) : null
         )
       ) : (
         <EmptyStateFooter text="당신은 친구도 없고 글도 없네요 호호" />


### PR DESCRIPTION
## 설명

현재는 ‘나도’를 누르려면 반드시 글 상세 페이지까지 진입해야하는데, 글 목록에서도 ‘나도’를 바로 누를 수 있게 한다.

## 해당 브랜치에서 할 일

- [x]  PostPreview 컴포넌트에서도 바로 ‘나도’를 누를 수 있도록 한다
- [x]  ‘나도’가 눌린 상태를 낙관적으로 변경한다

## 계획에 없었는데 함께 끝낸 일

없음 

## 메모

없음