### PR TITLE
친구 신청 디자인 작성

### DIFF
--- a/app/(tabs)/me/page.tsx
+++ b/app/(tabs)/me/page.tsx
@@ -19,6 +19,12 @@ async function getUser(userId: number) {
       login_id: true,
       avatar: true,
       bio: true,
+      _count: {
+        select: {
+          friends: true,
+          friendOf: true,
+        },
+      },
     },
   });
 

--- a/app/chat/layout.tsx
+++ b/app/chat/layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 export default async function Layout({ children }: LayoutProps) {
   return (
     <main className="max-w-2xl mx-auto">
-      <Header />
+      <Header canGoBack />
       <section className="mt-14 mb-20">{children}</section>
     </main>
   );

--- a/app/me/edit/layout.tsx
+++ b/app/me/edit/layout.tsx
@@ -1,0 +1,14 @@
+import Header from "@/components/layouts/header";
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="max-w-2xl mx-auto">
+      <Header title="프로필 수정" canGoBack />
+      <section className={"mt-14 mb-20"}>{children}</section>
+    </main>
+  );
+}

--- a/app/me/requested/layout.tsx
+++ b/app/me/requested/layout.tsx
@@ -1,0 +1,14 @@
+import Header from "@/components/layouts/header";
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="max-w-2xl mx-auto">
+      <Header title="받은 친구 신청" canGoBack />
+      <section className={"mt-14 mb-20"}>{children}</section>
+    </main>
+  );
+}

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -1,0 +1,70 @@
+"use server";
+
+import db from "@/libs/db";
+import getSession from "@/libs/session";
+import Image from "next/image";
+
+async function getFriendRequests(userId: number) {
+  const requests = await db.friendship.findMany({
+    where: {
+      recipientId: userId,
+      // status: 2,
+    },
+    include: {
+      initiator: {
+        select: {
+          id: true,
+          username: true,
+          avatar: true,
+          login_id: true,
+        },
+      },
+    },
+  });
+
+  return requests;
+}
+
+export default async function Requested() {
+  const session = await getSession();
+  const requests = await getFriendRequests(session.id!);
+  return (
+    <section className="flex flex-col gap-4 p-4">
+      {requests.map((request) => (
+        <div
+          key={request.id}
+          className="flex flex-col gap-4 p-4 bg-neutral-800 shadow-md rounded-md"
+        >
+          <div className="flex items-center gap-4">
+            {request.initiator.avatar ? (
+              <Image
+                src={request.initiator.avatar}
+                alt={request.initiator.username}
+                width={48}
+                height={48}
+                className="rounded-full"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-neutral-300" />
+            )}
+            <div className="flex flex-col">
+              <span className="font-medium">{request.initiator.username}</span>
+              <span className="text-xs text-neutral-500">
+                @{request.initiator.login_id}
+              </span>
+            </div>
+          </div>
+          <div>{request.text ?? "우리 친구해요!"}</div>
+          <div className="flex items-center gap-2">
+            <button className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2">
+              삭제
+            </button>
+            <button className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700">
+              친구하기
+            </button>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/app/posts/[id]/layout.tsx
+++ b/app/posts/[id]/layout.tsx
@@ -50,7 +50,7 @@ export default async function Layout({ children, params }: LayoutProps) {
 
   return (
     <main className="max-w-2xl mx-auto">
-      <Header profile={postUser}>
+      <Header profile={postUser} canGoBack>
         <PostDetailMoreBtns isUserPost={isUserPost} postId={postId} />
       </Header>
       <section className="mt-14 mb-20">{children}</section>

--- a/app/users/[id]/friends/page.tsx
+++ b/app/users/[id]/friends/page.tsx
@@ -1,0 +1,66 @@
+import db from "@/libs/db";
+import Image from "next/image";
+
+async function getFriends(loginId: string) {
+  const friends = await db.friendship.findMany({
+    where: {
+      OR: [
+        { initiator: { login_id: loginId } },
+        { recipient: { login_id: loginId } },
+      ],
+      status: 1,
+    },
+    include: {
+      initiator: {
+        select: {
+          id: true,
+          username: true,
+          avatar: true,
+          login_id: true,
+        },
+      },
+      recipient: {
+        select: {
+          id: true,
+          username: true,
+          avatar: true,
+          login_id: true,
+        },
+      },
+    },
+  });
+  return friends;
+}
+
+export default async function Friends({ params }: { params: { id: string } }) {
+  const { id } = await params;
+  const friendships = await getFriends(id);
+  const friends = friendships.map((friendship) =>
+    friendship.initiator.login_id === id
+      ? friendship.recipient
+      : friendship.initiator
+  );
+  return (
+    <section className="flex flex-col gap-4 p-4">
+      {friends.map((friend) => (
+        <div key={friend.id} className="flex items-center gap-4">
+          {friend.avatar ? (
+            <Image
+              src={friend.avatar}
+              alt={friend.username}
+              width={48}
+              height={48}
+              className="rounded-full"
+            />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-neutral-300" />
+          )}
+          <div className="flex flex-col">
+            <span className="font-medium">{friend.username}</span>
+            <span className="text-xs text-neutral-500">@{friend.login_id}</span>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/app/users/[id]/layout.tsx
+++ b/app/users/[id]/layout.tsx
@@ -31,7 +31,7 @@ export default async function Layout({
 
   return (
     <main className="max-w-2xl mx-auto">
-      <Header profile={user} />
+      <Header profile={user} canGoBack />
       <section className={"mt-14 mb-20"}>{children}</section>
     </main>
   );

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -13,6 +13,12 @@ async function getUser(userLoginId: string) {
       login_id: true,
       bio: true,
       avatar: true,
+      _count: {
+        select: {
+          friends: true,
+          friendOf: true,
+        },
+      },
     },
   });
 

--- a/app/users/[id]/send-request/page.tsx
+++ b/app/users/[id]/send-request/page.tsx
@@ -1,0 +1,16 @@
+import SubmitButton from "@/components/buttons/submit-button";
+import Textarea from "@/components/inputs/textarea";
+
+export default async function SendRequest({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id: loginId } = await params;
+  return (
+    <form className="flex flex-col gap-4 p-4">
+      <Textarea placeholder={`@${loginId} 님! 우리 친구해요!`} />
+      <SubmitButton text="친구 신청 보내기" />
+    </form>
+  );
+}

--- a/components/layouts/header.tsx
+++ b/components/layouts/header.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 
 interface HeaderProps {
   title?: string;
+  canGoBack?: boolean;
   profile?: {
     id: number;
     username: string;
@@ -16,20 +17,26 @@ interface HeaderProps {
   children?: React.ReactNode;
 }
 
-export default function Header({ title, profile, children }: HeaderProps) {
+export default function Header({
+  title,
+  canGoBack,
+  profile,
+  children,
+}: HeaderProps) {
   const router = useRouter();
   return (
     <header className="px-4 h-14 border-b-2 border-violet-600 dark:border-violet-400 text-center fixed flex justify-between top-0 max-w-2xl w-full bg-white dark:bg-neutral-800 z-20 shadow-md">
       <section className="flex items-center gap-4">
+        {canGoBack ? (
+          <button>
+            <ChevronLeftIcon onClick={router.back} className="size-6" />
+          </button>
+        ) : null}
         {title ? (
           <h1 className="text-lg font-bold text-violet-600 dark:text-violet-400">
             {title}
           </h1>
-        ) : (
-          <button>
-            <ChevronLeftIcon onClick={router.back} className="size-6" />
-          </button>
-        )}
+        ) : null}
         {profile ? (
           <Link
             href={`/users/${profile.login_id}`}

--- a/components/layouts/user-info.tsx
+++ b/components/layouts/user-info.tsx
@@ -14,6 +14,10 @@ interface UserTemplateProps {
     login_id: string;
     bio: string | null;
     avatar: string | null;
+    _count: {
+      friends: number;
+      friendOf: number;
+    };
   };
 }
 
@@ -22,30 +26,29 @@ export default function UserInfo({
   isFriend,
   profile,
 }: UserTemplateProps) {
+  const friendsCount = profile._count.friends + profile._count.friendOf;
   return (
     <section>
       <div className="h-56 bg-neutral-100 dark:bg-neutral-800 flex flex-col justify-end p-4 gap-3 relative">
         <div className="flex flex-col gap-3">
           <div className="absolute right-4 top-4 flex gap-2">
+            <Link
+              href={`/users/${profile.login_id}/friends`}
+              className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
+            >
+              <UsersIcon className="size-4" />
+              친구 목록 ({friendsCount})
+            </Link>
             {isMe ? (
-              <>
-                <Link
-                  href={`/users/${profile.login_id}/friends`}
-                  className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
-                >
-                  <UsersIcon className="size-4" />
-                  친구 (0)
-                </Link>
-                <Link
-                  href="/me/edit"
-                  className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
-                >
-                  <Cog6ToothIcon className="size-4" />
-                  설정
-                </Link>
-              </>
+              <Link
+                href="/me/edit"
+                className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
+              >
+                <Cog6ToothIcon className="size-4" />
+                설정
+              </Link>
             ) : null}
-            {!isMe && isFriend ? (
+            {!isMe && !isFriend ? (
               <Link
                 href={`/users/${profile.login_id}/send-request`}
                 className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"

--- a/components/layouts/user-info.tsx
+++ b/components/layouts/user-info.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { UserPlusIcon, UsersIcon } from "@heroicons/react/24/solid";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
@@ -19,18 +18,10 @@ interface UserTemplateProps {
 }
 
 export default function UserInfo({
-  isMe = false,
-  isFriend = false,
+  isMe,
+  isFriend,
   profile,
 }: UserTemplateProps) {
-  const router = useRouter();
-  const goToSettingPage = () => {
-    router.push(`/me/edit`);
-  };
-  const onSettingsClick = () => {
-    goToSettingPage();
-  };
-
   return (
     <section>
       <div className="h-56 bg-neutral-100 dark:bg-neutral-800 flex flex-col justify-end p-4 gap-3 relative">
@@ -39,30 +30,30 @@ export default function UserInfo({
             {isMe ? (
               <>
                 <Link
-                  href="/me/friends"
+                  href={`/users/${profile.login_id}/friends`}
                   className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
                 >
                   <UsersIcon className="size-4" />
                   친구 (0)
                 </Link>
-                <button
-                  onClick={onSettingsClick}
+                <Link
+                  href="/me/edit"
                   className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
                 >
                   <Cog6ToothIcon className="size-4" />
                   설정
-                </button>
+                </Link>
               </>
             ) : null}
-            {isMe || isFriend ? null : (
+            {!isMe && isFriend ? (
               <Link
-                href={`/users/{account_id}/create`}
+                href={`/users/${profile.login_id}/send-request`}
                 className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
               >
                 <UserPlusIcon className="size-4" />
                 친구 신청
               </Link>
-            )}
+            ) : null}
           </div>
           {profile?.avatar ? (
             <Image

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Friendship {
   status      Int      @default(2) // 0: rejected, 1: accepted, 2: pending
   created_at  DateTime @default(now())
   updated_at  DateTime @updatedAt
+  text        String?
   initiator   User     @relation("FriendsAsInitiator", fields: [initiatorId], references: [id])
   initiatorId Int
   recipient   User     @relation("FriendsAsRecipient", fields: [recipientId], references: [id])


### PR DESCRIPTION
## 설명

친구 신청을 보내는 화면, 받은 친구 신청 일란을 확인하는 화면의 디자인을 작성한다

## 해당 브랜치에서 할 일

- [x]  친구 신청 보내는 화면 작성
- [x]  받은 친구 신청 리스트 화면 작성

## 계획에 없었는데 함께 끝낸 일

-  친구 목록 페이지 작성
-  기존에는 타이틀이 없으면 자동으로 뒤로가기 버튼을 표시하는 방식이었으나, 뒤로 가기를 옵션으로 넘겨서 표시할 수 있도록 변경함.
- '나는' 페이지의 하위 레이아웃 작성
- 프로필 페이지에 표시할 버튼의 분기 처리 (본인 프로필, 타인 프로필, 친구 프로필)

## 메모

없음