### PR TITLE
친구신청 기능 구현

### DIFF
--- a/app/(tabs)/me/page.tsx
+++ b/app/(tabs)/me/page.tsx
@@ -19,16 +19,21 @@ async function getUser(userId: number) {
       login_id: true,
       avatar: true,
       bio: true,
-      _count: {
-        select: {
-          friends: true,
-          friendOf: true,
-        },
-      },
     },
   });
 
   return user;
+}
+
+async function getFriendsCount(userId: number) {
+  const friendsCount = await db.friendship.count({
+    where: {
+      OR: [{ initiatorId: userId }, { recipientId: userId }],
+      status: 1,
+    },
+  });
+
+  return friendsCount;
 }
 
 async function getPosts(userId: number) {
@@ -113,10 +118,11 @@ export default async function Me() {
   }
   const posts = await getPosts(session.id);
   const reposts = await getReposts(session.id);
+  const friendsCount = await getFriendsCount(session.id);
 
   return (
     <>
-      <UserInfo isMe={true} profile={user} />
+      <UserInfo isMe={true} profile={user} friendsCount={friendsCount} />
       <UserTimeline posts={posts} reposts={reposts} userId={session.id!} />
     </>
   );

--- a/app/(tabs)/me/page.tsx
+++ b/app/(tabs)/me/page.tsx
@@ -107,6 +107,17 @@ async function getReposts(userId: number) {
   return reposts;
 }
 
+async function getPendedCount(sessionId: number) {
+  const pendedCount = await db.friendship.count({
+    where: {
+      recipientId: sessionId,
+      status: 2,
+    },
+  });
+
+  return pendedCount;
+}
+
 export default async function Me() {
   const session = await getSession();
   if (!session.id) {
@@ -119,10 +130,15 @@ export default async function Me() {
   const posts = await getPosts(session.id);
   const reposts = await getReposts(session.id);
   const friendsCount = await getFriendsCount(session.id);
-
+  const pendedCount = await getPendedCount(session.id);
   return (
     <>
-      <UserInfo isMe={true} profile={user} friendsCount={friendsCount} />
+      <UserInfo
+        isMe={true}
+        profile={user}
+        friendsCount={friendsCount}
+        pendedCount={pendedCount}
+      />
       <UserTimeline posts={posts} reposts={reposts} userId={session.id!} />
     </>
   );

--- a/app/me/requested/action.ts
+++ b/app/me/requested/action.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import db from "@/libs/db";
+import getSession from "@/libs/session";
+import { revalidatePath } from "next/cache";
+
+export async function deleteRequest(initiatorId: number) {
+  try {
+    const session = await getSession();
+    await db.friendship.update({
+      where: {
+        initiatorId_recipientId: {
+          initiatorId: initiatorId,
+          recipientId: session.id!,
+        },
+        status: 2,
+      },
+      data: {
+        status: 0,
+      },
+    });
+    revalidatePath("/me/requested");
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: "친구 신청 삭제 실패",
+    };
+  }
+}
+
+export async function acceptRequest(initiatorId: number) {
+  try {
+    const session = await getSession();
+
+    await db.friendship.update({
+      where: {
+        initiatorId_recipientId: {
+          initiatorId: initiatorId,
+          recipientId: session.id!,
+        },
+        status: 2,
+      },
+      data: {
+        status: 1,
+      },
+    });
+    revalidatePath("/me/requested");
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: "친구 신청 수락 실패",
+    };
+  }
+}

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -4,6 +4,7 @@ import db from "@/libs/db";
 import getSession from "@/libs/session";
 import Image from "next/image";
 import ReceiveRequestForm from "@/components/forms/receive-request-form";
+import Link from "next/link";
 
 async function getFriendRequests(userId: number) {
   const requests = await db.friendship.findMany({
@@ -37,7 +38,10 @@ export default async function Requested() {
           key={request.id}
           className="flex flex-col gap-4 p-4 bg-neutral-800 shadow-md rounded-md"
         >
-          <div className="flex items-center gap-4">
+          <Link
+            href={`/users/${request.initiator.login_id}`}
+            className="flex items-center gap-4"
+          >
             {request.initiator.avatar ? (
               <Image
                 src={request.initiator.avatar}
@@ -55,7 +59,7 @@ export default async function Requested() {
                 @{request.initiator.login_id}
               </span>
             </div>
-          </div>
+          </Link>
           {request.text === "" ? (
             <p className="text-sm text-neutral-500">
               친구 신청 메시지가 없습니다

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -8,7 +8,7 @@ async function getFriendRequests(userId: number) {
   const requests = await db.friendship.findMany({
     where: {
       recipientId: userId,
-      // status: 2,
+      status: 2,
     },
     include: {
       initiator: {
@@ -54,12 +54,18 @@ export default async function Requested() {
               </span>
             </div>
           </div>
-          <div>{request.text ?? "우리 친구해요!"}</div>
-          <div className="flex items-center gap-2">
-            <button className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2">
+          {request.text === "" ? (
+            <p className="text-sm text-neutral-500">
+              친구 신청 메시지가 없습니다
+            </p>
+          ) : (
+            <p className="text-sm">{request.text}</p>
+          )}
+          <div className="flex items-center gap-2 mt-2">
+            <button className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2 text-sm">
               삭제
             </button>
-            <button className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700">
+            <button className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700 text-sm">
               친구하기
             </button>
           </div>

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -36,7 +36,7 @@ export default async function Requested() {
       {requests.map((request) => (
         <div
           key={request.id}
-          className="flex flex-col gap-4 p-4 bg-neutral-800 shadow-md rounded-md"
+          className="flex flex-col gap-4 p-4 bg-neutral-50 dark:bg-neutral-800 shadow-md rounded-md"
         >
           <Link
             href={`/users/${request.initiator.login_id}`}

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -44,7 +44,7 @@ export default async function Requested() {
                 alt={request.initiator.username}
                 width={48}
                 height={48}
-                className="rounded-full"
+                className="size-12 rounded-md"
               />
             ) : (
               <div className="w-12 h-12 rounded-full bg-neutral-300" />

--- a/app/me/requested/page.tsx
+++ b/app/me/requested/page.tsx
@@ -3,6 +3,7 @@
 import db from "@/libs/db";
 import getSession from "@/libs/session";
 import Image from "next/image";
+import ReceiveRequestForm from "@/components/forms/receive-request-form";
 
 async function getFriendRequests(userId: number) {
   const requests = await db.friendship.findMany({
@@ -28,6 +29,7 @@ async function getFriendRequests(userId: number) {
 export default async function Requested() {
   const session = await getSession();
   const requests = await getFriendRequests(session.id!);
+
   return (
     <section className="flex flex-col gap-4 p-4">
       {requests.map((request) => (
@@ -61,14 +63,7 @@ export default async function Requested() {
           ) : (
             <p className="text-sm">{request.text}</p>
           )}
-          <div className="flex items-center gap-2 mt-2">
-            <button className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2 text-sm">
-              삭제
-            </button>
-            <button className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700 text-sm">
-              친구하기
-            </button>
-          </div>
+          <ReceiveRequestForm {...request} />
         </div>
       ))}
     </section>

--- a/app/users/[id]/friends/page.tsx
+++ b/app/users/[id]/friends/page.tsx
@@ -1,5 +1,6 @@
 import db from "@/libs/db";
 import Image from "next/image";
+import Link from "next/link";
 
 async function getFriends(loginId: string) {
   const friends = await db.friendship.findMany({
@@ -47,23 +48,27 @@ export default async function Friends({
   return (
     <section className="flex flex-col gap-4 p-4">
       {friends.map((friend) => (
-        <div key={friend.id} className="flex items-center gap-4">
+        <Link
+          key={friend.id}
+          href={`/users/${friend.login_id}`}
+          className="flex items-center gap-4"
+        >
           {friend.avatar ? (
             <Image
               src={friend.avatar}
               alt={friend.username}
-              width={48}
-              height={48}
-              className="rounded-full"
+              width={40}
+              height={40}
+              className="size-10 rounded-md"
             />
           ) : (
             <div className="w-12 h-12 rounded-full bg-neutral-300" />
           )}
           <div className="flex flex-col">
-            <span className="font-medium">{friend.username}</span>
+            <span className="font-medium text-sm">{friend.username}</span>
             <span className="text-xs text-neutral-500">@{friend.login_id}</span>
           </div>
-        </div>
+        </Link>
       ))}
     </section>
   );

--- a/app/users/[id]/friends/page.tsx
+++ b/app/users/[id]/friends/page.tsx
@@ -1,6 +1,22 @@
 import db from "@/libs/db";
+import getSession from "@/libs/session";
+import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import Image from "next/image";
 import Link from "next/link";
+
+async function getIsMe(loginId: string) {
+  const session = await getSession();
+  const targetUser = await db.user.findUnique({
+    where: {
+      login_id: loginId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return targetUser?.id === session?.id;
+}
 
 async function getFriends(loginId: string) {
   const friends = await db.friendship.findMany({
@@ -33,6 +49,17 @@ async function getFriends(loginId: string) {
   return friends;
 }
 
+async function getPendingFriendsCount(loginId: string) {
+  const pendingFriendsCount = await db.friendship.count({
+    where: {
+      OR: [{ recipient: { login_id: loginId } }],
+      status: 2,
+    },
+  });
+
+  return pendingFriendsCount;
+}
+
 export default async function Friends({
   params,
 }: {
@@ -45,31 +72,52 @@ export default async function Friends({
       ? friendship.recipient
       : friendship.initiator
   );
+  const isMe = await getIsMe(loginId);
+  const pendingFriendsCount = await getPendingFriendsCount(loginId);
+
   return (
-    <section className="flex flex-col gap-4 p-4">
-      {friends.map((friend) => (
-        <Link
-          key={friend.id}
-          href={`/users/${friend.login_id}`}
-          className="flex items-center gap-4"
-        >
-          {friend.avatar ? (
-            <Image
-              src={friend.avatar}
-              alt={friend.username}
-              width={40}
-              height={40}
-              className="size-10 rounded-md"
-            />
-          ) : (
-            <div className="w-12 h-12 rounded-full bg-neutral-300" />
-          )}
-          <div className="flex flex-col">
-            <span className="font-medium text-sm">{friend.username}</span>
-            <span className="text-xs text-neutral-500">@{friend.login_id}</span>
-          </div>
-        </Link>
-      ))}
+    <section className="flex flex-col p-4 gap-4">
+      {isMe && pendingFriendsCount > 0 ? (
+        <div className="flex items-center justify-between h-8">
+          <span className="text-sm text-neutral-500">
+            {pendingFriendsCount}명의 친구 요청이 도착했어요.
+          </span>
+          <Link
+            href="/me/requested"
+            className="text-violet-600 dark:text-white font-bold text-sm flex items-center gap-2"
+          >
+            <span>보러가기</span>
+            <ChevronRightIcon className="size-4" />
+          </Link>
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-4">
+        {friends.map((friend) => (
+          <Link
+            key={friend.id}
+            href={`/users/${friend.login_id}`}
+            className="flex items-center gap-4"
+          >
+            {friend.avatar ? (
+              <Image
+                src={friend.avatar}
+                alt={friend.username}
+                width={40}
+                height={40}
+                className="size-10 rounded-md"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-neutral-300" />
+            )}
+            <div className="flex flex-col">
+              <span className="font-medium text-sm">{friend.username}</span>
+              <span className="text-xs text-neutral-500">
+                @{friend.login_id}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
     </section>
   );
 }

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -127,19 +127,23 @@ async function getIsFriend(userId: number, sessionId: number) {
   return Boolean(isFriend);
 }
 
+async function getIsPended(userId: number, sessionId: number) {
+  const isFriend = await db.friendship.findFirst({
+    where: {
+      initiatorId: userId,
+      recipientId: sessionId,
+      status: 2,
+    },
+  });
+
+  return Boolean(isFriend);
+}
+
 async function getIsPending(userId: number, sessionId: number) {
   const isFriend = await db.friendship.findFirst({
     where: {
-      OR: [
-        {
-          initiatorId: userId,
-          recipientId: sessionId,
-        },
-        {
-          initiatorId: sessionId,
-          recipientId: userId,
-        },
-      ],
+      initiatorId: sessionId,
+      recipientId: userId,
       status: 2,
     },
   });
@@ -162,6 +166,7 @@ export default async function Users({
   const isMe = user.id === session?.id;
   const isFriend = await getIsFriend(user.id, session.id!);
   const isPending = await getIsPending(user.id, session.id!);
+  const isPended = await getIsPended(user.id, session.id!);
   const friendsCount = await getFriendsCount(user.id);
 
   const posts = await getPosts(loginId);
@@ -174,6 +179,7 @@ export default async function Users({
         profile={user}
         isFriend={isFriend}
         isPending={isPending}
+        isPended={isPended}
         friendsCount={friendsCount}
       />
       <UserTimeline posts={posts} reposts={reposts} userId={user.id} />

--- a/app/users/[id]/send-request/action.ts
+++ b/app/users/[id]/send-request/action.ts
@@ -56,9 +56,20 @@ export async function sendFriendRequest(
     }
 
     if (session.id) {
-      await db.friendship.create({
-        data: {
+      await db.friendship.upsert({
+        where: {
+          initiatorId_recipientId: {
+            initiatorId: session.id,
+            recipientId: recipient.id,
+          },
+        },
+        update: {
           text: result.data.text,
+          status: 2,
+        },
+        create: {
+          text: result.data.text,
+          status: 2,
           initiator: {
             connect: {
               id: session.id,

--- a/app/users/[id]/send-request/action.ts
+++ b/app/users/[id]/send-request/action.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import db from "@/libs/db";
+import getSession from "@/libs/session";
+import { ActionPrevState } from "@/types/form";
+import { revalidatePath } from "next/cache";
+import { notFound, redirect } from "next/navigation";
+import { z } from "zod";
+
+export interface SendFriendRequestForm {
+  text: string;
+}
+
+const friendRequestSchema = z.object({
+  text: z.string().max(1000, "내용은 1000자 이하로 입력해주세요"),
+});
+
+export async function sendFriendRequest(
+  _: ActionPrevState<SendFriendRequestForm>,
+  formData: FormData,
+  recipientLoginId: string
+) {
+  try {
+    const data = {
+      text: formData.get("text"),
+    };
+    const result = await friendRequestSchema.spa(data);
+    if (!result.success) {
+      return result.error.flatten();
+    }
+
+    const recipient = await db.user.findUnique({
+      where: {
+        login_id: recipientLoginId,
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (!recipient) {
+      return notFound();
+    }
+
+    const session = await getSession();
+    const isFriend = await db.friendship.findFirst({
+      where: {
+        OR: [
+          { initiatorId: session.id, recipientId: recipient.id },
+          { initiatorId: recipient.id, recipientId: session.id },
+        ],
+        status: { in: [1, 2] },
+      },
+    });
+    if (isFriend) {
+      return redirect(`/users/${recipient.id}`);
+    }
+
+    if (session.id) {
+      await db.friendship.create({
+        data: {
+          text: result.data.text,
+          initiator: {
+            connect: {
+              id: session.id,
+            },
+          },
+          recipient: {
+            connect: {
+              id: recipient.id,
+            },
+          },
+        },
+      });
+    }
+
+    revalidatePath(`/users/${recipientLoginId}/friends`);
+    redirect(`/users/${recipientLoginId}`);
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/app/users/[id]/send-request/page.tsx
+++ b/app/users/[id]/send-request/page.tsx
@@ -1,5 +1,35 @@
-import SubmitButton from "@/components/buttons/submit-button";
-import Textarea from "@/components/inputs/textarea";
+import db from "@/libs/db";
+import getSession from "@/libs/session";
+import { notFound, redirect } from "next/navigation";
+import SendRequestForm from "@/components/forms/send-request-form";
+
+async function getRecipient(loginId: string) {
+  const recipient = await db.user.findUnique({
+    where: {
+      login_id: loginId,
+    },
+    select: {
+      id: true,
+      username: true,
+    },
+  });
+
+  return recipient;
+}
+
+async function getIsFriend(userId: number, recipientId: number) {
+  const isFriend = await db.friendship.findFirst({
+    where: {
+      OR: [
+        { initiatorId: userId, recipientId: recipientId },
+        { initiatorId: recipientId, recipientId: userId },
+      ],
+      status: { in: [1, 2] },
+    },
+  });
+
+  return isFriend;
+}
 
 export default async function SendRequest({
   params,
@@ -7,10 +37,20 @@ export default async function SendRequest({
   params: Promise<{ id: string }>;
 }) {
   const { id: loginId } = await params;
-  return (
-    <form className="flex flex-col gap-4 p-4">
-      <Textarea placeholder={`@${loginId} 님! 우리 친구해요!`} />
-      <SubmitButton text="친구 신청 보내기" />
-    </form>
-  );
+  const recipient = await getRecipient(loginId);
+  if (!recipient) {
+    return notFound();
+  }
+
+  const session = await getSession();
+  if (!session.id) {
+    return redirect("/login");
+  }
+
+  const isFriend = await getIsFriend(session.id, recipient.id);
+  if (isFriend) {
+    return redirect(`/users/${loginId}`);
+  }
+
+  return <SendRequestForm username={recipient.username} loginId={loginId} />;
 }

--- a/app/users/[id]/send-request/page.tsx
+++ b/app/users/[id]/send-request/page.tsx
@@ -49,7 +49,7 @@ export default async function SendRequest({
 
   const isFriend = await getIsFriend(session.id, recipient.id);
   if (isFriend) {
-    return redirect(`/users/${loginId}`);
+    return redirect("/me");
   }
 
   return <SendRequestForm username={recipient.username} loginId={loginId} />;

--- a/components/buttons/submit-button.tsx
+++ b/components/buttons/submit-button.tsx
@@ -20,7 +20,7 @@ const SubmitButton: NextPage<SubmitButtonProps> = ({
   const buttonColor = (color: "violet" | "red" | "gray") => {
     switch (color) {
       case "violet":
-        return "bg-violet-400 focus:ring-violet-600 text-white";
+        return "bg-violet-400 dark:bg-violet-600 focus:ring-violet-600 text-white";
       case "red":
         return "bg-rose-600 focus:ring-rose-700 text-white";
       case "gray":

--- a/components/forms/receive-request-form.tsx
+++ b/components/forms/receive-request-form.tsx
@@ -49,13 +49,13 @@ export default function ReceiveRequestForm({
     <div className="flex items-center gap-2 mt-2">
       <button
         onClick={onDeleteClick}
-        className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2 text-sm"
+        className="w-1/2 rounded-md bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-400 p-2 text-sm"
       >
         삭제
       </button>
       <button
         onClick={onAcceptClick}
-        className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700 text-sm"
+        className="w-1/2 rounded-md bg-violet-500 dark:bg-violet-600 p-2 text-white hover:bg-violet-700 text-sm"
       >
         친구하기
       </button>

--- a/components/forms/receive-request-form.tsx
+++ b/components/forms/receive-request-form.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { acceptRequest, deleteRequest } from "@/app/me/requested/action";
+import { alertAtom } from "@/libs/atoms";
+import { useSetAtom } from "jotai";
+
+interface ReceiveRequestFormProps {
+  id: number;
+  initiatorId: number;
+  recipientId: number;
+  status: number;
+  text: string | null;
+  created_at: Date;
+  updated_at: Date;
+  initiator: {
+    id: number;
+    username: string;
+    avatar: string | null;
+    login_id: string;
+  };
+}
+
+export default function ReceiveRequestForm({
+  initiator,
+}: ReceiveRequestFormProps) {
+  const setAlert = useSetAtom(alertAtom);
+  const onDeleteClick = async () => {
+    setAlert({
+      visible: true,
+      title: "삭제",
+      description: `${initiator.username}님의 친구 신청을 삭제할까요?`,
+      extraBtnColor: "red",
+      extraBtnText: "삭제하기",
+      extraBtnAction: () => deleteRequest(initiator.id),
+    });
+  };
+  const onAcceptClick = async () => {
+    setAlert({
+      visible: true,
+      title: "친구 신청",
+      description: `${initiator.username}님의 친구 신청을 수락할까요?`,
+      extraBtnColor: "green",
+      extraBtnText: "수락하기",
+      extraBtnAction: () => acceptRequest(initiator.id),
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <button
+        onClick={onDeleteClick}
+        className="w-1/2 rounded-md bg-neutral-600 hover:bg-neutral-400 p-2 text-sm"
+      >
+        삭제
+      </button>
+      <button
+        onClick={onAcceptClick}
+        className="w-1/2 rounded-md bg-violet-600 p-2 text-white hover:bg-violet-700 text-sm"
+      >
+        친구하기
+      </button>
+    </div>
+  );
+}

--- a/components/forms/send-request-form.tsx
+++ b/components/forms/send-request-form.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+  sendFriendRequest,
+  SendFriendRequestForm,
+} from "@/app/users/[id]/send-request/action";
+import SubmitButton from "../buttons/submit-button";
+import Textarea from "../inputs/textarea";
+import { useActionState } from "react";
+import { ActionPrevState } from "@/types/form";
+
+interface SendRequestFormProps {
+  username: string;
+  loginId: string;
+}
+
+export default function SendRequestForm({
+  username,
+  loginId,
+}: SendRequestFormProps) {
+  const [state, action] = useActionState(
+    (_: ActionPrevState<SendFriendRequestForm>, formData: FormData) =>
+      sendFriendRequest(_, formData, loginId),
+    null
+  );
+  return (
+    <form action={action} className="flex flex-col gap-4 p-4">
+      <Textarea
+        name="text"
+        placeholder={`${username}님, 저랑 친구해요!`}
+        errors={state?.fieldErrors.text}
+      />
+      <SubmitButton text="친구 신청 보내기" />
+    </form>
+  );
+}

--- a/components/layouts/user-info.tsx
+++ b/components/layouts/user-info.tsx
@@ -10,6 +10,7 @@ interface UserTemplateProps {
   isFriend?: boolean;
   isPending?: boolean;
   isPended?: boolean;
+  pendedCount?: number;
   profile: {
     id: number;
     username: string;
@@ -25,6 +26,7 @@ export default function UserInfo({
   isFriend,
   isPending,
   isPended,
+  pendedCount,
   profile,
   friendsCount,
 }: UserTemplateProps) {
@@ -35,10 +37,15 @@ export default function UserInfo({
           <div className="absolute right-4 top-4 flex gap-2">
             <Link
               href={`/users/${profile.login_id}/friends`}
-              className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
+              className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1 relative"
             >
+              {pendedCount ? (
+                <div className="flex items-center justify-center size-4 bg-red-600 rounded-full absolute -top-2 -right-2">
+                  <span className="text-xs text-white">{pendedCount}</span>
+                </div>
+              ) : null}
               <UsersIcon className="size-4" />
-              친구 ({friendsCount})
+              친구 목록 ({friendsCount})
             </Link>
             {isMe ? (
               <Link

--- a/components/layouts/user-info.tsx
+++ b/components/layouts/user-info.tsx
@@ -9,6 +9,7 @@ interface UserTemplateProps {
   isMe?: boolean;
   isFriend?: boolean;
   isPending?: boolean;
+  isPended?: boolean;
   profile: {
     id: number;
     username: string;
@@ -23,6 +24,7 @@ export default function UserInfo({
   isMe,
   isFriend,
   isPending,
+  isPended,
   profile,
   friendsCount,
 }: UserTemplateProps) {
@@ -36,7 +38,7 @@ export default function UserInfo({
               className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
             >
               <UsersIcon className="size-4" />
-              친구 목록 ({friendsCount})
+              친구 ({friendsCount})
             </Link>
             {isMe ? (
               <Link
@@ -47,7 +49,7 @@ export default function UserInfo({
                 설정
               </Link>
             ) : null}
-            {!isMe && !isFriend && !isPending ? (
+            {!isMe && !isFriend && !isPending && !isPended ? (
               <Link
                 href={`/users/${profile.login_id}/send-request`}
                 className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
@@ -84,6 +86,11 @@ export default function UserInfo({
               {isMe ? (
                 <span className="text-xs font-bold bg-neutral-200 dark:bg-neutral-600 px-2 py-1 rounded-md text-neutral-600 dark:text-neutral-200">
                   내 프로필
+                </span>
+              ) : null}
+              {isPended ? (
+                <span className="text-xs font-bold bg-neutral-200 dark:bg-neutral-600 px-2 py-1 rounded-md text-neutral-600 dark:text-neutral-200">
+                  친구 요청 받음
                 </span>
               ) : null}
             </div>

--- a/components/layouts/user-info.tsx
+++ b/components/layouts/user-info.tsx
@@ -8,25 +8,24 @@ import Image from "next/image";
 interface UserTemplateProps {
   isMe?: boolean;
   isFriend?: boolean;
+  isPending?: boolean;
   profile: {
     id: number;
     username: string;
     login_id: string;
     bio: string | null;
     avatar: string | null;
-    _count: {
-      friends: number;
-      friendOf: number;
-    };
   };
+  friendsCount: number;
 }
 
 export default function UserInfo({
   isMe,
   isFriend,
+  isPending,
   profile,
+  friendsCount,
 }: UserTemplateProps) {
-  const friendsCount = profile._count.friends + profile._count.friendOf;
   return (
     <section>
       <div className="h-56 bg-neutral-100 dark:bg-neutral-800 flex flex-col justify-end p-4 gap-3 relative">
@@ -48,7 +47,7 @@ export default function UserInfo({
                 설정
               </Link>
             ) : null}
-            {!isMe && !isFriend ? (
+            {!isMe && !isFriend && !isPending ? (
               <Link
                 href={`/users/${profile.login_id}/send-request`}
                 className="border border-violet-400 dark:border-white bg-white dark:bg-neutral-800 px-2 py-1 text-sm rounded-md text-violet-400 dark:text-white flex items-center gap-1"
@@ -70,12 +69,29 @@ export default function UserInfo({
             <div className="w-12 h-12 bg-neutral-300 dark:bg-neutral-500 rounded-md" />
           )}
           <div className="flex flex-col">
-            <h5 className="font-semibold">{profile?.username}</h5>
+            <div className="flex items-center gap-3">
+              <h5 className="font-semibold">{profile?.username}</h5>
+              {isFriend ? (
+                <span className="text-xs font-bold bg-violet-600 px-2 py-1 rounded-md text-neutral-200">
+                  친구
+                </span>
+              ) : null}
+              {isPending ? (
+                <span className="text-xs font-bold bg-neutral-200 dark:bg-neutral-600 px-2 py-1 rounded-md text-neutral-600 dark:text-neutral-200">
+                  친구 요청 보냄
+                </span>
+              ) : null}
+              {isMe ? (
+                <span className="text-xs font-bold bg-neutral-200 dark:bg-neutral-600 px-2 py-1 rounded-md text-neutral-600 dark:text-neutral-200">
+                  내 프로필
+                </span>
+              ) : null}
+            </div>
             <p className="text-gray-400 text-sm">@{profile?.login_id}</p>
           </div>
         </div>
         {profile?.bio ? (
-          <p className="text-xs text-slate-600">{profile?.bio}</p>
+          <p className="text-xs text-neutral-600">{profile?.bio}</p>
         ) : null}
       </div>
     </section>

--- a/components/post-preview-profile.tsx
+++ b/components/post-preview-profile.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+interface PostPreviewProfileProps {
+  avatar: string | null;
+  username: string;
+  loginId: string;
+}
+
+export default function PostPreviewProfile({
+  avatar,
+  username,
+  loginId,
+}: PostPreviewProfileProps) {
+  return (
+    <Link
+      prefetch={false}
+      href={`/users/${loginId}`}
+      className="flex items-center gap-3"
+    >
+      {avatar ? (
+        <Image
+          src={avatar}
+          alt={username}
+          width={40}
+          height={40}
+          className="size-10 rounded-md bg-neutral-200 dark:bg-neutral-600 object-cover shadow-sm"
+        />
+      ) : (
+        <div className="size-10 bg-neutral-200 dark:bg-neutral-600 rounded-md shadow-sm" />
+      )}
+      <div className="flex flex-col">
+        <h2 className="font-semibold text-sm">{username}</h2>
+      </div>
+    </Link>
+  );
+}

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -5,6 +5,7 @@ import { PostWithUser } from "./timeline";
 import { formatRelativeTime } from "@/libs/utils";
 import Image from "next/image";
 import PostPreviewButtons from "./buttons/post-preview-buttons";
+import { useRouter } from "next/navigation";
 
 interface PostPreviewProps {
   post: PostWithUser;
@@ -15,15 +16,22 @@ export default function PostPreview({
   post: { id, user, content, tags, created_at, _count, reposts },
   userId,
 }: PostPreviewProps) {
+  const router = useRouter();
   const isUserPost = Number(user.id) === userId;
   const isUserReposted = reposts.some((repost) => repost?.id);
+
+  const goToUserPage = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    router.push(`/users/${user.login_id}`);
+  };
 
   return (
     <Link href={`/posts/${id}`}>
       <div className="w-full p-4 text-left flex flex-col gap-3">
         {/* 프로필 */}
         <section className="flex justify-between items-center">
-          <div className="flex items-center gap-3">
+          <button onClick={goToUserPage} className="flex items-center gap-3">
             <Image
               src={user.avatar ?? ""}
               alt={user.username}
@@ -34,7 +42,7 @@ export default function PostPreview({
             <div className="flex flex-col">
               <h2 className="font-semibold text-sm">{user.username}</h2>
             </div>
-          </div>
+          </button>
           <p className="text-sm text-neutral-400">
             {formatRelativeTime(created_at)}
           </p>

--- a/components/repost-preview.tsx
+++ b/components/repost-preview.tsx
@@ -6,6 +6,7 @@ import { formatRelativeTime } from "@/libs/utils";
 import Image from "next/image";
 import PostPreviewButtons from "./buttons/post-preview-buttons";
 import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
+import { useRouter } from "next/navigation";
 
 interface RepostPreviewProps {
   repost: RepostWithUser;
@@ -27,8 +28,14 @@ export default function RepostPreview({
   },
   userId,
 }: RepostPreviewProps) {
+  const router = useRouter();
   const isUserPost = Number(postUser.id) === userId;
   const isUserReposted = reposts.some((repost) => repost?.id);
+  const goToUserPage = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    router.push(`/users/${postUser.login_id}`);
+  };
 
   return (
     <Link href={`/posts/${postId}`}>
@@ -39,7 +46,7 @@ export default function RepostPreview({
         </div>
         {/* 프로필 */}
         <section className="flex justify-between items-center">
-          <div className="flex items-center gap-3">
+          <button onClick={goToUserPage} className="flex items-center gap-3">
             <Image
               src={postUser.avatar ?? ""}
               alt={postUser.username}
@@ -50,7 +57,7 @@ export default function RepostPreview({
             <div className="flex flex-col">
               <h2 className="font-semibold text-sm">{postUser.username}</h2>
             </div>
-          </div>
+          </button>
           <p className="text-sm text-neutral-400">
             {formatRelativeTime(postCreatedAt)}
           </p>


### PR DESCRIPTION
## 설명

친구신청 디자인은 완성했으므로 이제 디자인을 추가합니다

## 해당 브랜치에서 할 일

- [x]  친구신청 보내기 기능 구현
- [x]  받은 친구신청 목록 확인하고 수락 혹은 거절하는 기능 추가
- [x]  이미 친구 신청을 보낸 유저에게는 친구신청을 보내지 못하도록 제한

## 계획에 없었는데 함께 끝낸 일

- 게시글 및 재게시글 미리보기 화면에서 프로필 미리보기 누르면 바로 프로필로 이동
- 친구 목록에서 친구 프로필 클릭 시 프로필 페이지로 바로 이동
- 받은 친구신청의 숫자를 본인 프로필에 표시
- 프로필을 볼 때 친구, 친구신청 보낸 사람, 친구신청 받은 사람의 상태를 알 수 있도록 함

## 메모

- 친구 신청 보낼때, 과거 거절한 이력이 있을 경우에는 해당 레코드를 수정하도록 작성함. (데이터베이스 상으로는 가장 최근의 친구 상태만을 확인할 수 있음. 이력은 로그로 볼 수 있도록.)