### PR TITLE
사진 업로드 및 열람 기능 구현

### DIFF
--- a/app/(common)/action.ts
+++ b/app/(common)/action.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import * as constants from "@/libs/constants";
+
+export async function getUploadUrl() {
+  const response = await fetch(constants.CF_DIRECT_UPLOAD_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${process.env.CF_API_TOKEN}` },
+  });
+  const data = await response.json();
+
+  return data;
+}

--- a/app/me/setting/action.ts
+++ b/app/me/setting/action.ts
@@ -60,13 +60,3 @@ export async function updateProfile(
     redirect("/me");
   }
 }
-
-export async function getUploadUrl() {
-  const response = await fetch(constants.CF_DIRECT_UPLOAD_URL, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${process.env.CF_API_TOKEN}` },
-  });
-  const data = await response.json();
-
-  return data;
-}

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -9,6 +9,8 @@ import {
 import { notFound } from "next/navigation";
 import CommentForm from "@/components/forms/comment-form";
 import RepostForm from "@/components/forms/detail-repost-form";
+import Image from "next/image";
+import Link from "next/link";
 
 async function getPost(postId: number) {
   const post = await db.post.findUnique({
@@ -71,6 +73,21 @@ export default async function PostDetail({
       <section className="divide-y pb-16">
         {/* 본문 */}
         <div className="flex flex-col p-4 gap-2 shadow-md">
+          {post.photos.length ? (
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {post.photos.map((photo) => (
+                <Link href={`${photo}/public`} key={photo}>
+                  <Image
+                    src={photo + "/avatar"}
+                    alt="post-photo"
+                    className="rounded-md aspect-video object-cover"
+                    width={1600}
+                    height={1000}
+                  />
+                </Link>
+              ))}
+            </div>
+          ) : null}
           <h5>{post.content}</h5>
           <p className="text-sm text-neutral-400">{post.tags}</p>
           <div className="flex justify-between pt-6 items-center">

--- a/app/posts/upload/action.ts
+++ b/app/posts/upload/action.ts
@@ -8,9 +8,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { ActionPrevState } from "@/types/form";
 
-interface UploadPostForm {
+export interface UploadPostForm {
   content: string;
   tags: string;
+  photos: string[];
 }
 
 const postSchema = z.object({
@@ -24,6 +25,7 @@ const postSchema = z.object({
   tags: z
     .string()
     .max(constants.POST_TAGS_MAX_LENGTH, constants.POST_TAGS_MAX_ERROR_MESSAGE),
+  photos: z.array(z.string()).max(4, constants.POST_PHOTOS_MAX_ERROR_MESSAGE),
 });
 
 export async function uploadPost(
@@ -33,6 +35,7 @@ export async function uploadPost(
   const data = {
     content: formData.get("content"),
     tags: formData.get("tags"),
+    photos: JSON.parse(formData.get("photos") as string),
   };
   const result = await postSchema.spa(data);
 
@@ -45,11 +48,8 @@ export async function uploadPost(
       data: {
         content: result.data.content,
         tags: result.data.tags,
-        user: {
-          connect: {
-            id: session.id,
-          },
-        },
+        userId: session.id,
+        photos: result.data.photos,
       },
       select: {
         id: true,

--- a/components/alert-dialog.tsx
+++ b/components/alert-dialog.tsx
@@ -13,6 +13,7 @@ export default function AlertDialog() {
       visible,
       title,
       description,
+      descriptionElement,
       closeBtn = true,
       closeBtnAction,
       extraBtnText,
@@ -63,6 +64,7 @@ export default function AlertDialog() {
             {title}
           </ReactAlertDialog.Title>
           <ReactAlertDialog.Description className="mt-4 mb-5 leading-normal">
+            {descriptionElement}
             {description}
           </ReactAlertDialog.Description>
           <div className="flex justify-end gap-4">

--- a/components/buttons/submit-button.tsx
+++ b/components/buttons/submit-button.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { cls } from "@/libs/utils";
 import { NextPage } from "next";
-import { useFormStatus } from "react-dom";
 
 interface SubmitButtonProps {
   text: string;
   type?: "button" | "submit" | "reset";
   onClick?: () => void;
   color?: "violet" | "red" | "gray";
+  pending?: boolean;
 }
 
 const SubmitButton: NextPage<SubmitButtonProps> = ({
@@ -16,6 +15,7 @@ const SubmitButton: NextPage<SubmitButtonProps> = ({
   type = "submit",
   onClick,
   color = "violet",
+  pending,
 }) => {
   const buttonColor = (color: "violet" | "red" | "gray") => {
     switch (color) {
@@ -24,20 +24,17 @@ const SubmitButton: NextPage<SubmitButtonProps> = ({
       case "red":
         return "bg-rose-600 focus:ring-rose-700 text-white";
       case "gray":
-        return "bg-gray-200 focus:ring-gray-400 text-black";
+        return "bg-neutral-200 focus:ring-neutral-400 text-white";
     }
   };
-  const { pending } = useFormStatus();
   return (
     <button
       type={type}
       onClick={onClick}
       disabled={pending}
-      className={cls(
-        "px-4 py-2 rounded-md outline-none focus:ring-2 ",
-        buttonColor(color),
-        pending ? "bg-neutral-400 text-black" : ""
-      )}
+      className={`px-4 py-2 rounded-md outline-none focus:ring-2 ${buttonColor(
+        pending ? "gray" : color
+      )} ${pending ? "opacity-50 cursor-not-allowed" : ""}`}
     >
       {pending ? "로딩 중..." : text}
     </button>

--- a/components/forms/edit-profile-form.tsx
+++ b/components/forms/edit-profile-form.tsx
@@ -4,16 +4,13 @@ import { PencilIcon } from "@heroicons/react/24/solid";
 import ProfileImage from "../profile-image";
 import { useActionState, useState } from "react";
 import Textarea from "../inputs/textarea";
-import {
-  getUploadUrl,
-  updateProfile,
-  UpdateProfileForm,
-} from "@/app/me/setting/action";
+import { updateProfile, UpdateProfileForm } from "@/app/me/setting/action";
 import { useSetAtom } from "jotai";
 import { alertAtom } from "@/libs/atoms";
 import { ActionPrevState } from "@/types/form";
 import { getImageUrl } from "@/libs/utils";
 import SubmitButton from "../buttons/submit-button";
+import { getUploadUrl } from "@/app/(common)/action";
 
 interface EditProfileFormProps {
   username: string;

--- a/components/forms/edit-profile-form.tsx
+++ b/components/forms/edit-profile-form.tsx
@@ -13,6 +13,7 @@ import { useSetAtom } from "jotai";
 import { alertAtom } from "@/libs/atoms";
 import { ActionPrevState } from "@/types/form";
 import { getImageUrl } from "@/libs/utils";
+import SubmitButton from "../buttons/submit-button";
 
 interface EditProfileFormProps {
   username: string;
@@ -102,7 +103,7 @@ export default function EditProfileForm({
     }
   };
 
-  const [state, action] = useActionState(updateProfileWrapper, null);
+  const [state, action, pending] = useActionState(updateProfileWrapper, null);
 
   return (
     <form action={action}>
@@ -138,9 +139,7 @@ export default function EditProfileForm({
           defaultValue={bio ?? ""}
           errors={state?.fieldErrors.bio}
         />
-        <button className="mt-4 bg-violet-400 dark:bg-violet-600 focus:ring-violet-600 text-white w-full py-2 rounded-md outline-none focus:ring-2">
-          프로필 업데이트
-        </button>
+        <SubmitButton text="프로필 업데이트" pending={pending} />
       </div>
     </form>
   );

--- a/components/forms/login-form.tsx
+++ b/components/forms/login-form.tsx
@@ -7,7 +7,7 @@ import { useActionState } from "react";
 import { PASSWORD_MIN_LENGTH } from "@/libs/constants";
 
 export default function LoginForm() {
-  const [state, action] = useActionState(login, null);
+  const [state, action, pending] = useActionState(login, null);
   return (
     <form action={action} className="flex flex-col gap-4 p-8">
       <TextInput
@@ -21,10 +21,13 @@ export default function LoginForm() {
         type="password"
         placeholder="비밀번호"
         required={true}
-        errors={state?.fieldErrors.password}
+        errors={[
+          ...(state?.fieldErrors?.login_id ?? []),
+          ...(state?.fieldErrors?.password ?? []),
+        ]}
         minLength={PASSWORD_MIN_LENGTH}
       />
-      <SubmitButton text="로그인" />
+      <SubmitButton text="로그인" pending={pending} />
     </form>
   );
 }

--- a/components/forms/register-form.tsx
+++ b/components/forms/register-form.tsx
@@ -14,7 +14,7 @@ export default function RegisterForm() {
     const { name, value } = event.target;
     setFormState((prev) => ({ ...prev, [name]: value }));
   };
-  const [state, action] = useActionState(register, null);
+  const [state, action, pending] = useActionState(register, null);
 
   return (
     <form action={action} className="flex flex-col gap-4 p-8">
@@ -51,7 +51,7 @@ export default function RegisterForm() {
         errors={state?.fieldErrors.username}
         warning="다른 이용자에게 불쾌감을 줄 수 있는 별명은 삼가주세요!"
       />
-      <SubmitButton text="회원가입" />
+      <SubmitButton text="회원가입" pending={pending} />
     </form>
   );
 }

--- a/components/forms/upload-form.tsx
+++ b/components/forms/upload-form.tsx
@@ -4,11 +4,40 @@ import { PlusIcon } from "@heroicons/react/24/solid";
 import SubmitButton from "../buttons/submit-button";
 import TextInput from "../inputs/text-input";
 import Textarea from "../inputs/textarea";
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
 import { uploadPost } from "@/app/posts/upload/action";
+import { useSetAtom } from "jotai";
+import { alertAtom } from "@/libs/atoms";
+import Image from "next/image";
+
+const maxImages = 4;
 
 export default function UploadForm() {
   const [state, action] = useActionState(uploadPost, null);
+  const [previews, setPreviews] = useState<string[]>([]);
+  const setAlert = useSetAtom(alertAtom);
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    // 이미 업로드된 이미지 수 확인
+    if (previews.length + files.length > maxImages) {
+      setAlert({
+        visible: true,
+        title: "너무 많아요!",
+        description: `이미지는 최대 ${maxImages}개까지만 업로드할 수 있어요.`,
+      });
+      return;
+    }
+
+    // 파일 미리보기 생성
+    const newPreviews = Array.from(files).map((file) =>
+      URL.createObjectURL(file)
+    );
+    setPreviews((prev) => [...prev, ...newPreviews]);
+  };
+
   return (
     <form action={action} className="flex flex-col gap-3">
       <Textarea
@@ -22,14 +51,44 @@ export default function UploadForm() {
         placeholder="태그 작성.."
         errors={state?.fieldErrors.tags}
       />
-      <div>
-        <label
-          htmlFor="media"
-          className="w-14 h-14 border-2 border-dashed rounded-md text-neutral-300 flex justify-center items-center hover:text-neutral-700 hover:border-neutral-700 dark:hover:text-neutral-400 dark:hover:border-neutral-400 hover:cursor-pointer"
-        >
-          <PlusIcon className="size-6" />
-        </label>
-        <input type="file" className="hidden" id="media" />
+      <div className="flex gap-2">
+        <div>
+          <label
+            htmlFor="photos"
+            className={`w-14 h-14 border-2 border-dashed rounded-md text-neutral-300 flex justify-center items-center ${
+              previews.length >= maxImages
+                ? "opacity-50 cursor-not-allowed"
+                : "cursor-pointer hover:text-neutral-700 hover:border-neutral-700 dark:hover:text-neutral-400 dark:hover:border-neutral-400"
+            }`}
+          >
+            <PlusIcon
+              className={`size-6 ${
+                previews.length >= maxImages ? "rotate-45" : ""
+              }`}
+            />
+          </label>
+          <input
+            multiple
+            type="file"
+            accept="image/*"
+            className="hidden"
+            id="photos"
+            name="photos"
+            disabled={previews.length >= maxImages}
+            onChange={onFileChange}
+          />
+        </div>
+        {previews.map((preview, index) => (
+          <button key={index} type="button">
+            <Image
+              src={preview}
+              alt="preview"
+              className="size-14 rounded-md"
+              width={56}
+              height={56}
+            />
+          </button>
+        ))}
       </div>
       <SubmitButton text="글쓰기" />
     </form>

--- a/components/forms/upload-form.tsx
+++ b/components/forms/upload-form.tsx
@@ -5,29 +5,101 @@ import SubmitButton from "../buttons/submit-button";
 import TextInput from "../inputs/text-input";
 import Textarea from "../inputs/textarea";
 import { useActionState, useState } from "react";
-import { uploadPost } from "@/app/posts/upload/action";
+import { uploadPost, UploadPostForm } from "@/app/posts/upload/action";
 import { useSetAtom } from "jotai";
 import { alertAtom } from "@/libs/atoms";
 import Image from "next/image";
+import { getUploadUrl } from "@/app/(common)/action";
+import { ActionPrevState } from "@/types/form";
+import { getImageUrl } from "@/libs/utils";
 
+const maxImageSizeMb = 5;
 const maxImages = 4;
 
 export default function UploadForm() {
-  const [state, action] = useActionState(uploadPost, null);
   const [previews, setPreviews] = useState<string[]>([]);
+  const [uploadUrls, setUploadUrls] = useState<
+    { id: string; uploadURL: string; file: File }[]
+  >([]);
   const setAlert = useSetAtom(alertAtom);
 
-  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const validateImageFile = (file: File) => {
+    if (file.size > 1024 * 1024 * maxImageSizeMb) {
+      throw new Error(`${maxImageSizeMb}MB 이하의 이미지만 업로드 가능합니다.`);
+    }
+    if (!file.type.startsWith("image/")) {
+      throw new Error("이미지 파일만 업로드 가능합니다.");
+    }
+  };
+
+  const uploadImage = async (file: File, uploadUrl: string) => {
+    if (!file) return "";
+
+    const cloudflareFormData = new FormData();
+    cloudflareFormData.append("file", file);
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      body: cloudflareFormData,
+    });
+    if (response.status !== 200) {
+      throw new Error(
+        "이미지 저장소에 문제가 있는 것 같아요. 잠시 후에 다시 시도해주세요."
+      );
+    }
+  };
+
+  const onPreviewClick = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    preview: string,
+    index: number
+  ) => {
+    e.preventDefault();
+    setAlert({
+      visible: true,
+      title: "아래 이미지를 삭제할까요?",
+      descriptionElement: (
+        <Image
+          src={preview}
+          alt="preview"
+          width={1600}
+          height={1000}
+          className="object-cover rounded-md"
+        />
+      ),
+      extraBtn: true,
+      extraBtnColor: "red",
+      extraBtnText: "삭제하기",
+      extraBtnAction: () => {
+        setPreviews((prev) => prev.filter((_, i) => i !== index));
+        setUploadUrls((prev) => prev.filter((_, i) => i !== index));
+      },
+      closeBtn: true,
+    });
+  };
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
 
-    // 이미 업로드된 이미지 수 확인
-    if (previews.length + files.length > maxImages) {
-      setAlert({
-        visible: true,
-        title: "너무 많아요!",
-        description: `이미지는 최대 ${maxImages}개까지만 업로드할 수 있어요.`,
+    try {
+      Array.from(files).forEach((file) => {
+        validateImageFile(file);
       });
+
+      // 이미 업로드된 이미지 수 확인
+      if (previews.length + files.length > maxImages) {
+        throw new Error(
+          `이미지는 최대 ${maxImages}개까지만 업로드할 수 있어요.`
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        setAlert({
+          visible: true,
+          title: "잠시만요!",
+          description: error.message,
+        });
+      }
       return;
     }
 
@@ -36,7 +108,45 @@ export default function UploadForm() {
       URL.createObjectURL(file)
     );
     setPreviews((prev) => [...prev, ...newPreviews]);
+
+    // 업로드 URL 발급
+    Array.from(files).forEach(async (file) => {
+      const { success, result } = await getUploadUrl();
+      if (success) {
+        const { id, uploadURL } = result;
+        setUploadUrls((prev) => [...prev, { id, uploadURL, file }]);
+      }
+    });
   };
+
+  const uploadPostWrapper = async (
+    state: ActionPrevState<UploadPostForm>,
+    formData: FormData
+  ) => {
+    try {
+      if (!uploadUrls) return;
+      if (uploadUrls.length > 4) return;
+
+      let imageUrls: string[] = [];
+      await Promise.all(
+        uploadUrls.map(async ({ id, uploadURL, file }) => {
+          await uploadImage(file, uploadURL);
+          const imageUrl = getImageUrl(id);
+          imageUrls = [...imageUrls, imageUrl];
+        })
+      );
+      formData.set("photos", JSON.stringify(imageUrls));
+
+      return uploadPost(state, formData);
+    } catch (e) {
+      setAlert({
+        visible: true,
+        title: "죄송해요!",
+        description: (e as Error).message,
+      });
+    }
+  };
+  const [state, action, pending] = useActionState(uploadPostWrapper, null);
 
   return (
     <form action={action} className="flex flex-col gap-3">
@@ -79,18 +189,22 @@ export default function UploadForm() {
           />
         </div>
         {previews.map((preview, index) => (
-          <button key={index} type="button">
+          <button
+            key={index}
+            type="button"
+            onClick={(e) => onPreviewClick(e, preview, index)}
+          >
             <Image
               src={preview}
               alt="preview"
-              className="size-14 rounded-md"
+              className="size-14 rounded-md object-cover"
               width={56}
               height={56}
             />
           </button>
         ))}
       </div>
-      <SubmitButton text="글쓰기" />
+      <SubmitButton text="글쓰기" pending={pending} />
     </form>
   );
 }

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -6,6 +6,7 @@ import { formatRelativeTime } from "@/libs/utils";
 import PostPreviewButtons from "./buttons/post-preview-buttons";
 import { useRouter } from "next/navigation";
 import ProfileImage from "./profile-image";
+import Image from "next/image";
 
 interface PostPreviewProps {
   post: PostWithUser;
@@ -13,7 +14,7 @@ interface PostPreviewProps {
 }
 
 export default function PostPreview({
-  post: { id, user, content, tags, created_at, _count, reposts },
+  post: { id, user, content, tags, photos, created_at, _count, reposts },
   userId,
 }: PostPreviewProps) {
   const router = useRouter();
@@ -45,6 +46,22 @@ export default function PostPreview({
         {/* 본문 & 태그 */}
         <p>{content}</p>
         <p className="text-sm text-neutral-400">{tags}</p>
+
+        {/* 이미지 */}
+        {photos.length ? (
+          <div className="grid grid-cols-2 gap-2">
+            {photos.map((photo) => (
+              <Image
+                key={photo}
+                src={photo + "/avatar"}
+                alt="post-photo"
+                className="rounded-md aspect-video object-cover shadow-sm"
+                width={1600}
+                height={1000}
+              />
+            ))}
+          </div>
+        ) : null}
 
         {/* 버튼부 */}
         <PostPreviewButtons

--- a/components/user-timeline.tsx
+++ b/components/user-timeline.tsx
@@ -44,6 +44,8 @@ export default function UserTimeline({
     (repost) => !originalPostIds.has(repost.post.id)
   );
 
+  const allMediaPosts = posts.filter((post) => post.photos.length > 0);
+
   const allPosts = [...posts, ...filteredReposts].sort(
     (prev, curr) =>
       new Date(curr.created_at).getTime() - new Date(prev.created_at).getTime()
@@ -83,7 +85,17 @@ export default function UserTimeline({
           )}
         </div>
       ) : null}
-      {currentTab === "media" ? <div>media</div> : null}
+      {currentTab === "media" ? (
+        <div className="flex flex-col divide-y divide-neutral-200 dark:divide-neutral-600">
+          {allMediaPosts.length ? (
+            allMediaPosts.map((post) => (
+              <PostPreview key={post.id} post={post} userId={userId} />
+            ))
+          ) : (
+            <EmptyState text="아직 미디어가 없어요!" userInfo />
+          )}
+        </div>
+      ) : null}
       {currentTab === "reposts" ? (
         <div className="flex flex-col divide-y divide-neutral-200 dark:divide-neutral-600">
           {reposts.length ? (

--- a/libs/atoms.ts
+++ b/libs/atoms.ts
@@ -7,6 +7,8 @@ export interface Alert {
   title?: string;
   // 모달 설명
   description?: string;
+  // 모달 설명 요소
+  descriptionElement?: React.ReactNode;
   // 닫기 버튼 표시 여부
   closeBtn?: boolean;
   // 닫기 버튼 클릭 시 실행할 함수

--- a/libs/constants.ts
+++ b/libs/constants.ts
@@ -12,6 +12,7 @@ export const POST_CONTENT_MAX_LENGTH = 150;
 export const POST_TAGS_MAX_LENGTH = 150;
 export const COMMENT_CONTENT_MAX_LENGTH = 1000;
 export const BIO_MAX_LENGTH = 200;
+export const POST_PHOTOS_MAX_LENGTH = 4;
 
 // Error messages
 export const INVALID_TYPE_ERROR_MESSAGE = "유효하지 않은 형식입니다";
@@ -37,6 +38,7 @@ export const POST_TAGS_MAX_ERROR_MESSAGE = `태그가 너무 길어요`;
 export const COMMENT_CONTENT_MAX_ERROR_MESSAGE = `최대 ${COMMENT_CONTENT_MAX_LENGTH}자의 댓글만 작성할 수 있어요`;
 export const COMMENT_CONTENT_REQUIRED_ERROR_MESSAGE = `댓글 내용을 입력해주세요`;
 export const BIO_MAX_ERROR_MESSAGE = `자기소개는 최대 ${BIO_MAX_LENGTH}자까지만 작성할 수 있어요`;
+export const POST_PHOTOS_MAX_ERROR_MESSAGE = `최대 ${POST_PHOTOS_MAX_LENGTH}장의 사진까지 업로드 할 수 있어요`;
 
 // Friendship Status
 export const FRIEND_REJECTED = 0;

--- a/libs/utils.ts
+++ b/libs/utils.ts
@@ -34,5 +34,5 @@ export function formatRelativeTime(targetDate: Date): string {
 }
 
 export function getImageUrl(imageId: string) {
-  return `https://imagedelivery.net/${process.env.CF_ACCOUNT_HASH}/${imageId}`;
+  return `https://imagedelivery.net/${process.env.NEXT_PUBLIC_CF_ACCOUNT_HASH}/${imageId}`;
 }

--- a/prisma/migrations/20250125121622_add_photos_to_posts/migration.sql
+++ b/prisma/migrations/20250125121622_add_photos_to_posts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "photos" TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Post {
   id         Int       @id @default(autoincrement())
   content    String
   tags       String?
+  photos     String[]
   views      Int       @default(0)
   is_deleted Boolean   @default(false)
   created_at DateTime  @default(now())


### PR DESCRIPTION
## 설명

현재는 텍스트 글만 작성할 수 있는데, 이미지도 최대 4개까지 업로드 할 수 있도록 한다. 또한 업로드한 이미지를 볼 수 있도록 한다.

## 해당 브랜치에서 할 일

- [x]  이미지 업로드를 위해 사용할 서비스를 조사한다
- [x]  이미지 업로드를 4개까지 할 수 있도록 DB 구조를 개선한다
- [x]  이미지 업로드 기능을 구현한다
- [x]  게시글에 이미지가 있는 경우 표시하는 UI를 작성한다
- [x]  프로필 페이지에서 특정 유저가 작성한 미디어만 모아볼 수 있는 기능을 추가한다

## 계획에 없었는데 함께 끝낸 일

- Submit Button의 비활성화 상태 디자인 수정
- 프로필 이미지 업로드 안되던 관련 오류 수정
- 로그인에서 오류 발생 시 비밀번호 필드 밑에만 오류 출력하도록 수정
- 이미지 업로드를 위한 URL을 취득하는 함수를 (common) 폴더 밑으로 이동시켜 공통화
- Alert Dialog에서 텍스트 이외에도 React Element를 표시할 수 있는 기능 추가

## 메모

없음